### PR TITLE
Changed to make it work on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Adjust PROJECT to where to find the files.
 
 
 ## Running
-Test everything:          make  
-Test without recompile:   make a  
+Test everything:          make
 Test mandatory:           make m  
 Test bonus:               make b  

--- a/gnl_test_bonus.c
+++ b/gnl_test_bonus.c
@@ -68,6 +68,37 @@ static int	count_static_file(int fd)
 	return (count);
 }
 
+/*
+	strnstr implemented from Libc for FreeBSD.
+	https://opensource.apple.com/source/Libc/Libc-391.2.10/string/FreeBSD/strnstr.c.auto.html.
+*/
+
+static char	*strnstr(const char *s, const char *find, size_t slen)
+{
+	char 	c;
+	char 	sc;
+	size_t	len;
+
+	if ((c = *find++) != '\0')
+	{
+		len = strlen(find);
+		do
+		{
+			do
+			{
+				if (slen-- < 1 || (sc = *s++) == '\0')
+					return (NULL);
+			}
+			while (sc != c);
+			if (len > slen)
+				return (NULL);
+		}
+		while (strncmp(s, find, len) != 0);
+		s--;
+	}
+	return ((char *)s);
+}
+
 static int	counter(char *buff)
 {
 	int	i;
@@ -130,7 +161,7 @@ static void	check_gnl_bonus_multiple_fd(void)
 	int		lines[5] = {0, 0, 0, 0, 0};
 	char	***check_array;
 
-	check_array = (char ***)calloc(sizeof(char **), OPEN_MAX);
+	check_array = (char ***)calloc(sizeof(char **), FOPEN_MAX);
 	printf(C_BOLD"\nMultiple file descriptors, in randomized order."C_RESET"\n");
 	open1_and_close2((int *)fd, 1);
 	add_fds_to_array((int *)lines, check_array, (int *) fd);

--- a/gnl_test_mandatory.c
+++ b/gnl_test_mandatory.c
@@ -50,7 +50,7 @@ static void	check_gnl(char *name, int tests)
 		printf(C_DGREY"[KO]"C_RESET" ");
 		return ;
 	}
-	check_array = (char ***)calloc(sizeof(char **), OPEN_MAX);
+	check_array = (char ***)calloc(sizeof(char **), FOPEN_MAX);
 	create_check_array(check_array, fd);
 	run_gnl_tests(name, check_array, fd, tests);
 	close(fd);

--- a/gnl_test_prototypes.h
+++ b/gnl_test_prototypes.h
@@ -4,10 +4,10 @@
 
 # include "h_colors.h"
 
-# include <stdlib.h>	//calloc, random, free, system, signal, exit
-# include <stdio.h>	//printf
-# include <fcntl.h>	//open
-# include <limits.h>	//OPEN_MAX
+# include <stdlib.h>	//calloc, random, free, system, exit
+# include <signal.h>	//signal
+# include <stdio.h>		//printf, FOPEN_MAX
+# include <fcntl.h>		//open
 # include <unistd.h>	//read, close
 # include <string.h>	//strcmp, memcpy, strlen
 

--- a/gnl_test_utils.c
+++ b/gnl_test_utils.c
@@ -52,7 +52,7 @@ void	free_check_array(char ***check_array)
 
 	fd = 0;
 	line = 0;
-	while (fd < OPEN_MAX)
+	while (fd < FOPEN_MAX)
 	{
 		if (check_array[fd])
 		{

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/sh
+SHELL := /bin/bash
 
 CC = gcc
 CFLAGS = -Wall -Wextra -Werror


### PR DESCRIPTION
Hello !

Out of the box, the tester wasn't working for me. I don't know if you used another BSD-based OS or macOS. I use a Docker Dev Container, running Ubuntu 22.04 LTS (ubuntu:latest) with only the following installed : build-essential valgrind zsh curl gcc make libbsd-dev git-core clang python3-pip (and norminette).

In order to make it work, I made a few changes :

- Makefile : changed /bin/sh to /bin/bash, as running with /bin/sh gave me this error : `[[: not found`. (https://superuser.com/a/374433)
- Added signal.h : signal() is in signal.h
- Implemented strnstr() : strnstr() is not a standard C function and is find in the bsd library string.h. We could use the -lbsd flag with gcc, but it might not work everywhere, if libbsd-dev is not installed for exemple, so I copied the function directly from a BSD library.
- Changed OPEN_MAX to FOPEN_MAX : OPEN_MAX is deprecated on some Linux system, it's better to use FOPEN_MAX which is in stdio.h (https://stackoverflow.com/a/14057714)
- Removed the mention to `make a` on the Readme : it's not implemented in the Makefile so I removed it

By the way, thanks for the tester :)